### PR TITLE
Xither. 

### DIFF
--- a/quither-proc-macros/src/lib.rs
+++ b/quither-proc-macros/src/lib.rs
@@ -76,11 +76,11 @@ struct CodeProcessor {
 
 impl VisitMut for CodeProcessor {
     fn visit_path_mut(&mut self, node: &mut Path) {
-        // Type `Quither<L, R>` or `Quither<L, R, has_either, has_neither, has_both>` will be
+        // Type `Xither<L, R>` or `Xither<L, R, has_either, has_neither, has_both>` will be
         // replaced with something like `EitherOrBoth<L, R>` depend on the bool arguments.
         for segment in node.segments.iter_mut() {
             self.replace_quither_path_segment(segment, |ident, new_part| {
-                ident.to_string().replace("Quither", new_part)
+                ident.to_string().replace("Xither", new_part)
             });
         }
         visit_path_mut(self, node);
@@ -151,7 +151,7 @@ impl CodeProcessor {
         F: FnOnce(&str, &str) -> String,
     {
         let ident_string = segment.ident.to_string();
-        if !ident_string.contains("Quither") {
+        if !ident_string.contains("Xither") {
             return;
         }
         let Some(bool_args) = self.implicit_345th_bool_arguments_for_path_segment(segment) else {
@@ -185,9 +185,9 @@ impl CodeProcessor {
         }
 
         let ident_str = ident.to_string();
-        if let Some(_) = ident_str.find("Quither") {
+        if let Some(_) = ident_str.find("Xither") {
             let new_ident_str = ident_str.replace(
-                "Quither",
+                "Xither",
                 Self::quither_name_gen((self.has_either, self.has_neither, self.has_both)),
             );
             *ident = Ident::new(&new_ident_str, ident.span());
@@ -469,15 +469,15 @@ fn test_visit_path_mut() {
     };
     let span = Span::call_site();
 
-    let mut path = parse_quote_spanned! { span => Quither<L, R> };
+    let mut path = parse_quote_spanned! { span => Xither<L, R> };
     cp.visit_path_mut(&mut path);
     assert_eq!(path, parse_quote_spanned! { span => EitherOrBoth<L, R> });
 
-    let mut path = parse_quote_spanned! { span => Quither<L, R, false, false, true> };
+    let mut path = parse_quote_spanned! { span => Xither<L, R, false, false, true> };
     cp.visit_path_mut(&mut path);
     assert_eq!(path, parse_quote_spanned! { span => Both<L, R, > });
 
-    let mut path = parse_quote_spanned! { span => Quither<L, R, has_both, has_both, has_neither> };
+    let mut path = parse_quote_spanned! { span => Xither<L, R, has_both, has_both, has_neither> };
     cp.visit_path_mut(&mut path);
     assert_eq!(
         path,

--- a/quither-proc-macros/src/lib.rs
+++ b/quither-proc-macros/src/lib.rs
@@ -37,6 +37,7 @@ use ::syn::{
 /// Without passing any arguments, this macro copies the annotated item 7 times, with:
 ///  - Replacing the path segment `Xither` (without generic parameters) or `Xither<X, Y>` (with 2 generic parameters)
 ///    with `Either`, `Neither`, `Both`, `EitherOrNeither`, `EitherOrBoth` or `NeitherOrBoth`.
+///    MAKE SURE TO NOT EXPOSE THE NAME `Xither` TO THE `quither` CRATE'S PUBLIC API OR DOCUMENTATION.
 ///  - Replacing the path segment like `Xither<X, Y, e, n, b>`, where `e`, `n`, and `b` are boolean
 ///    constants, with corresponding variant types like `Either<X, Y>`, `EitherOrBoth<X, Y>`, etc.
 ///    `e`, `n`, and `b` indicate whether the corresponding variant type has `Either`, `Neither`,

--- a/quither/README.md
+++ b/quither/README.md
@@ -1,3 +1,7 @@
+[![Crates.io Version](https://img.shields.io/crates/v/quither)](https://crates.io/crates/quither)
+[![docs.rs](https://img.shields.io/docsrs/quither)](https://docs.rs/quither/latest/quither/)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/wada314/quither)
+
 # quither
 
 A flexible enum-based utility for representing values that may be on the left, right, neither, or both sides.

--- a/quither/README.md
+++ b/quither/README.md
@@ -8,7 +8,12 @@ A flexible enum-based utility for representing values that may be on the left, r
 - Iterator and standard trait support
   - More and clearer iterator types than `itertools`'s `Either` and `EitherOrBoth` types.
 - (Supposed to) have compatible interfaces with `itertools`'s `Either` and `EitherOrBoth` types.
+- Fallible `map` methods, like `try_map()` or `try_map_left()`.
+- Convert between each variant types.
+  - Expanding conversion like `Either` to `EitherOrBoth` is infallible.
+  - Contracting conversion like `EitherOrBoth` to `Either` is fallible, where the error type returns the remaining variant type (`Both` in this case).
 - No-std compatible, can be build without `std` features.
+- A bonus feature: Supports the transposition of `Result<impl IntoIterator, E>` type into `impl Iterator<Item = Result<T, E>>` type.
 
 ## Example
 ```rust
@@ -18,7 +23,7 @@ use quither::{Quither, NeitherOrBoth, EitherOrBoth};
 let left: Quither<i32, i32> = Quither::Left(1);
 let right: Quither<i32, i32> = Quither::Right(2);
 let both: Quither<i32, i32> = Quither::Both(1, 2);
-let neither: Quither<i32, i32> = Quither::Neither;
+let neither = Neither::Neither;
 let left2: EitherOrBoth<i32, i32> = EitherOrBoth::Left(1);
 
 // Pattern matching on Quither
@@ -29,7 +34,10 @@ match both {
     Quither::Neither => println!("Neither"),
 }
 
-// You can also convert between different variant sets using TryInto:
+// You can convert the type to a "larger" type
+let left2_in_quither: Quither<_, _> = left2.into();
+
+// You can also convert into a "smaller" type with fallible conversion.
 // For example, convert a Quither to a type with only Neither and Both variants
 let neither_or_both: NeitherOrBoth<_, _> = both.try_into().unwrap();
 

--- a/quither/src/and_or_getters.rs
+++ b/quither/src/and_or_getters.rs
@@ -16,7 +16,7 @@ use super::*;
 use quither_proc_macros::quither;
 
 #[quither]
-impl<L, R> Quither<L, R> {
+impl<L, R> Xither<L, R> {
     /// Returns the left value, or the provided value if not present.
     ///
     /// If the left value is present, returns it. Otherwise, returns the provided value.
@@ -194,17 +194,17 @@ impl<L, R> Quither<L, R> {
     /// If the left value is present, applies the function and returns the result. Otherwise, returns
     /// the original value with the same variant.
     #[quither(has_either || has_both)]
-    pub fn left_and_then<F, L2>(self, f: F) -> Quither<L2, R>
+    pub fn left_and_then<F, L2>(self, f: F) -> Xither<L2, R>
     where
-        F: FnOnce(L) -> Quither<L2, R>,
+        F: FnOnce(L) -> Xither<L2, R>,
     {
         match self {
             #[either]
             Self::Left(l) => f(l),
             #[either]
-            Self::Right(r) => Quither::Right(r),
+            Self::Right(r) => Xither::Right(r),
             #[neither]
-            Self::Neither => Quither::Neither,
+            Self::Neither => Xither::Neither,
             #[both]
             Self::Both(l, _) => f(l),
         }
@@ -215,17 +215,17 @@ impl<L, R> Quither<L, R> {
     /// If the right value is present, applies the function and returns the result. Otherwise, returns
     /// the original value with the same variant.
     #[quither(has_either || has_both)]
-    pub fn right_and_then<F, R2>(self, f: F) -> Quither<L, R2>
+    pub fn right_and_then<F, R2>(self, f: F) -> Xither<L, R2>
     where
-        F: FnOnce(R) -> Quither<L, R2>,
+        F: FnOnce(R) -> Xither<L, R2>,
     {
         match self {
             #[either]
-            Self::Left(l) => Quither::Left(l),
+            Self::Left(l) => Xither::Left(l),
             #[either]
             Self::Right(r) => f(r),
             #[neither]
-            Self::Neither => Quither::Neither,
+            Self::Neither => Xither::Neither,
             #[both]
             Self::Both(_, r) => f(r),
         }

--- a/quither/src/as_ref.rs
+++ b/quither/src/as_ref.rs
@@ -25,40 +25,40 @@ use ::std::ffi::OsStr;
 use ::std::path::Path;
 
 #[quither]
-impl<L, R> Quither<L, R> {
+impl<L, R> Xither<L, R> {
     /// Creates a new variant with references to the contained values.
     #[quither(has_either || has_neither || has_both)]
-    pub fn as_ref(&self) -> Quither<&L, &R> {
+    pub fn as_ref(&self) -> Xither<&L, &R> {
         match self {
             #[either]
-            Self::Left(l) => Quither::Left(l),
+            Self::Left(l) => Xither::Left(l),
             #[either]
-            Self::Right(r) => Quither::Right(r),
+            Self::Right(r) => Xither::Right(r),
             #[neither]
-            Self::Neither => Quither::Neither,
+            Self::Neither => Xither::Neither,
             #[both]
-            Self::Both(l, r) => Quither::Both(l, r),
+            Self::Both(l, r) => Xither::Both(l, r),
         }
     }
 
     /// Creates a new variant with mutable references to the contained values.
     #[quither(has_either || has_neither || has_both)]
-    pub fn as_mut(&mut self) -> Quither<&mut L, &mut R> {
+    pub fn as_mut(&mut self) -> Xither<&mut L, &mut R> {
         match self {
             #[either]
-            Self::Left(l) => Quither::Left(l),
+            Self::Left(l) => Xither::Left(l),
             #[either]
-            Self::Right(r) => Quither::Right(r),
+            Self::Right(r) => Xither::Right(r),
             #[neither]
-            Self::Neither => Quither::Neither,
+            Self::Neither => Xither::Neither,
             #[both]
-            Self::Both(l, r) => Quither::Both(l, r),
+            Self::Both(l, r) => Xither::Both(l, r),
         }
     }
 
     /// Creates a new pinned variant with references to the contained values.
     #[quither(has_either || has_neither || has_both)]
-    pub fn as_pin_ref(self: Pin<&Self>) -> Quither<Pin<&L>, Pin<&R>> {
+    pub fn as_pin_ref(self: Pin<&Self>) -> Xither<Pin<&L>, Pin<&R>> {
         // SAFETY: This is safe because:
         // 1. We never move the inner values - we only create a new reference to them
         // 2. The original Pin<&Self> guarantees that the original data won't move
@@ -68,20 +68,20 @@ impl<L, R> Quither<L, R> {
         unsafe {
             match self.get_ref() {
                 #[either]
-                Self::Left(l) => Quither::Left(Pin::new_unchecked(l)),
+                Self::Left(l) => Xither::Left(Pin::new_unchecked(l)),
                 #[either]
-                Self::Right(r) => Quither::Right(Pin::new_unchecked(r)),
+                Self::Right(r) => Xither::Right(Pin::new_unchecked(r)),
                 #[neither]
-                Self::Neither => Quither::Neither,
+                Self::Neither => Xither::Neither,
                 #[both]
-                Self::Both(l, r) => Quither::Both(Pin::new_unchecked(l), Pin::new_unchecked(r)),
+                Self::Both(l, r) => Xither::Both(Pin::new_unchecked(l), Pin::new_unchecked(r)),
             }
         }
     }
 
     /// Creates a new pinned variant with mutable references to the contained values.
     #[quither(has_either || has_neither || has_both)]
-    pub fn as_pin_mut(self: Pin<&mut Self>) -> Quither<Pin<&mut L>, Pin<&mut R>> {
+    pub fn as_pin_mut(self: Pin<&mut Self>) -> Xither<Pin<&mut L>, Pin<&mut R>> {
         // SAFETY: This is safe because:
         // 1. We never move the inner values out of the pin
         // 2. We're creating new Pin instances from references to pinned data
@@ -91,52 +91,52 @@ impl<L, R> Quither<L, R> {
         unsafe {
             match self.get_unchecked_mut() {
                 #[either]
-                Self::Left(l) => Quither::Left(Pin::new_unchecked(l)),
+                Self::Left(l) => Xither::Left(Pin::new_unchecked(l)),
                 #[either]
-                Self::Right(r) => Quither::Right(Pin::new_unchecked(r)),
+                Self::Right(r) => Xither::Right(Pin::new_unchecked(r)),
                 #[neither]
-                Self::Neither => Quither::Neither,
+                Self::Neither => Xither::Neither,
                 #[both]
-                Self::Both(l, r) => Quither::Both(Pin::new_unchecked(l), Pin::new_unchecked(r)),
+                Self::Both(l, r) => Xither::Both(Pin::new_unchecked(l), Pin::new_unchecked(r)),
             }
         }
     }
 
     /// Returns a new value using the `Deref` trait for `L` and `R` values.
     #[quither(has_either || has_both)]
-    pub fn as_deref(&self) -> Quither<&L::Target, &R::Target>
+    pub fn as_deref(&self) -> Xither<&L::Target, &R::Target>
     where
         L: Deref,
         R: Deref,
     {
         match self {
             #[either]
-            Self::Left(l) => Quither::Left(l.deref()),
+            Self::Left(l) => Xither::Left(l.deref()),
             #[either]
-            Self::Right(r) => Quither::Right(r.deref()),
+            Self::Right(r) => Xither::Right(r.deref()),
             #[neither]
-            Self::Neither => Quither::Neither,
+            Self::Neither => Xither::Neither,
             #[both]
-            Self::Both(l, r) => Quither::Both(l.deref(), r.deref()),
+            Self::Both(l, r) => Xither::Both(l.deref(), r.deref()),
         }
     }
 
     /// Returns a new value using the `DerefMut` trait for `L` and `R` values.
     #[quither(has_either || has_both)]
-    pub fn as_deref_mut(&mut self) -> Quither<&mut L::Target, &mut R::Target>
+    pub fn as_deref_mut(&mut self) -> Xither<&mut L::Target, &mut R::Target>
     where
         L: DerefMut,
         R: DerefMut,
     {
         match self {
             #[either]
-            Self::Left(l) => Quither::Left(l.deref_mut()),
+            Self::Left(l) => Xither::Left(l.deref_mut()),
             #[either]
-            Self::Right(r) => Quither::Right(r.deref_mut()),
+            Self::Right(r) => Xither::Right(r.deref_mut()),
             #[neither]
-            Self::Neither => Quither::Neither,
+            Self::Neither => Xither::Neither,
             #[both]
-            Self::Both(l, r) => Quither::Both(l.deref_mut(), r.deref_mut()),
+            Self::Both(l, r) => Xither::Both(l.deref_mut(), r.deref_mut()),
         }
     }
 }

--- a/quither/src/conv.rs
+++ b/quither/src/conv.rs
@@ -26,43 +26,43 @@ impl<L, R> From<Result<R, L>> for Either<L, R> {
 
 /// Promotes a type without `Both` variant to a type with `Both` variant.
 #[quither(has_both && (has_either || has_neither))]
-impl<L, R> From<Quither<L, R, has_either, has_neither, false>> for Quither<L, R> {
-    fn from(quither: Quither<L, R, has_either, has_neither, false>) -> Self {
+impl<L, R> From<Xither<L, R, has_either, has_neither, false>> for Xither<L, R> {
+    fn from(quither: Xither<L, R, has_either, has_neither, false>) -> Self {
         match quither {
             #[either]
-            Quither::<L, R, has_either, has_neither, false>::Left(l) => Quither::Left(l),
+            Xither::<L, R, has_either, has_neither, false>::Left(l) => Xither::Left(l),
             #[either]
-            Quither::<L, R, has_either, has_neither, false>::Right(r) => Quither::Right(r),
+            Xither::<L, R, has_either, has_neither, false>::Right(r) => Xither::Right(r),
             #[neither]
-            Quither::<L, R, has_either, has_neither, false>::Neither => Quither::Neither,
+            Xither::<L, R, has_either, has_neither, false>::Neither => Xither::Neither,
         }
     }
 }
 
 /// Promotes a type without `Either` variant to a type with `Either` variant.
 #[quither(has_either && (has_neither || has_both))]
-impl<L, R> From<Quither<L, R, false, has_neither, has_both>> for Quither<L, R> {
-    fn from(quither: Quither<L, R, false, has_neither, has_both>) -> Self {
+impl<L, R> From<Xither<L, R, false, has_neither, has_both>> for Xither<L, R> {
+    fn from(quither: Xither<L, R, false, has_neither, has_both>) -> Self {
         match quither {
             #[neither]
-            Quither::<L, R, false, has_neither, has_both>::Neither => Quither::Neither,
+            Xither::<L, R, false, has_neither, has_both>::Neither => Xither::Neither,
             #[both]
-            Quither::<L, R, false, has_neither, has_both>::Both(l, r) => Quither::Both(l, r),
+            Xither::<L, R, false, has_neither, has_both>::Both(l, r) => Xither::Both(l, r),
         }
     }
 }
 
 /// Promotes a type without `Neither` variant to a type with `Neither` variant.
 #[quither(has_neither && (has_either || has_both))]
-impl<L, R> From<Quither<L, R, has_either, false, has_both>> for Quither<L, R> {
-    fn from(quither: Quither<L, R, has_either, false, has_both>) -> Self {
+impl<L, R> From<Xither<L, R, has_either, false, has_both>> for Xither<L, R> {
+    fn from(quither: Xither<L, R, has_either, false, has_both>) -> Self {
         match quither {
             #[either]
-            Quither::<L, R, has_either, false, has_both>::Left(l) => Quither::Left(l),
+            Xither::<L, R, has_either, false, has_both>::Left(l) => Xither::Left(l),
             #[either]
-            Quither::<L, R, has_either, false, has_both>::Right(r) => Quither::Right(r),
+            Xither::<L, R, has_either, false, has_both>::Right(r) => Xither::Right(r),
             #[both]
-            Quither::<L, R, has_either, false, has_both>::Both(l, r) => Quither::Both(l, r),
+            Xither::<L, R, has_either, false, has_both>::Both(l, r) => Xither::Both(l, r),
         }
     }
 }
@@ -95,98 +95,96 @@ impl<L, R> From<Both<L, R>> for Quither<L, R> {
 
 /// Demotes a type with `Either` variant to a type without `Either` variant.
 #[quither(!has_either)]
-impl<L, R> TryFrom<Quither<L, R, true, has_neither, has_both>> for Quither<L, R> {
+impl<L, R> TryFrom<Xither<L, R, true, has_neither, has_both>> for Xither<L, R> {
     type Error = Either<L, R>;
-    fn try_from(quither: Quither<L, R, true, has_neither, has_both>) -> Result<Self, Self::Error> {
+    fn try_from(quither: Xither<L, R, true, has_neither, has_both>) -> Result<Self, Self::Error> {
         match quither {
-            Quither::<L, R, true, has_neither, has_both>::Left(l) => Err(Either::Left(l)),
-            Quither::<L, R, true, has_neither, has_both>::Right(r) => Err(Either::Right(r)),
+            Xither::<L, R, true, has_neither, has_both>::Left(l) => Err(Either::Left(l)),
+            Xither::<L, R, true, has_neither, has_both>::Right(r) => Err(Either::Right(r)),
             #[neither]
-            Quither::<L, R, true, has_neither, has_both>::Neither => Ok(Quither::Neither),
+            Xither::<L, R, true, has_neither, has_both>::Neither => Ok(Xither::Neither),
             #[both]
-            Quither::<L, R, true, has_neither, has_both>::Both(l, r) => Ok(Quither::Both(l, r)),
+            Xither::<L, R, true, has_neither, has_both>::Both(l, r) => Ok(Xither::Both(l, r)),
         }
     }
 }
 
 /// Demotes a type with `Neither` variant to a type without `Neither` variant.
 #[quither(!has_neither)]
-impl<L, R> TryFrom<Quither<L, R, has_either, true, has_both>> for Quither<L, R> {
+impl<L, R> TryFrom<Xither<L, R, has_either, true, has_both>> for Xither<L, R> {
     type Error = Neither;
-    fn try_from(quither: Quither<L, R, has_either, true, has_both>) -> Result<Self, Self::Error> {
+    fn try_from(quither: Xither<L, R, has_either, true, has_both>) -> Result<Self, Self::Error> {
         match quither {
             #[either]
-            Quither::<L, R, has_either, true, has_both>::Left(l) => Ok(Quither::Left(l)),
+            Xither::<L, R, has_either, true, has_both>::Left(l) => Ok(Xither::Left(l)),
             #[either]
-            Quither::<L, R, has_either, true, has_both>::Right(r) => Ok(Quither::Right(r)),
-            Quither::<L, R, has_either, true, has_both>::Neither => Err(Neither::Neither),
+            Xither::<L, R, has_either, true, has_both>::Right(r) => Ok(Xither::Right(r)),
+            Xither::<L, R, has_either, true, has_both>::Neither => Err(Neither::Neither),
             #[both]
-            Quither::<L, R, has_either, true, has_both>::Both(l, r) => Ok(Quither::Both(l, r)),
+            Xither::<L, R, has_either, true, has_both>::Both(l, r) => Ok(Xither::Both(l, r)),
         }
     }
 }
 
 /// Demotes a type with `Both` variant to a type without `Both` variant.
 #[quither(!has_both)]
-impl<L, R> TryFrom<Quither<L, R, has_either, has_neither, true>> for Quither<L, R> {
+impl<L, R> TryFrom<Xither<L, R, has_either, has_neither, true>> for Xither<L, R> {
     type Error = Both<L, R>;
-    fn try_from(
-        quither: Quither<L, R, has_either, has_neither, true>,
-    ) -> Result<Self, Self::Error> {
+    fn try_from(quither: Xither<L, R, has_either, has_neither, true>) -> Result<Self, Self::Error> {
         match quither {
             #[either]
-            Quither::<L, R, has_either, has_neither, true>::Left(l) => Ok(Quither::Left(l)),
+            Xither::<L, R, has_either, has_neither, true>::Left(l) => Ok(Xither::Left(l)),
             #[either]
-            Quither::<L, R, has_either, has_neither, true>::Right(r) => Ok(Quither::Right(r)),
+            Xither::<L, R, has_either, has_neither, true>::Right(r) => Ok(Xither::Right(r)),
             #[neither]
-            Quither::<L, R, has_either, has_neither, true>::Neither => Ok(Quither::Neither),
-            Quither::<L, R, has_either, has_neither, true>::Both(l, r) => Err(Both::Both(l, r)),
+            Xither::<L, R, has_either, has_neither, true>::Neither => Ok(Xither::Neither),
+            Xither::<L, R, has_either, has_neither, true>::Both(l, r) => Err(Both::Both(l, r)),
         }
     }
 }
 
 /// Demotes a type with `Either` and `Neither` variants to a type without those variants.
 #[quither(!has_either && !has_neither)]
-impl<L, R> TryFrom<Quither<L, R, true, true, has_both>> for Quither<L, R> {
+impl<L, R> TryFrom<Xither<L, R, true, true, has_both>> for Xither<L, R> {
     type Error = EitherOrNeither<L, R>;
-    fn try_from(quither: Quither<L, R, true, true, has_both>) -> Result<Self, Self::Error> {
+    fn try_from(quither: Xither<L, R, true, true, has_both>) -> Result<Self, Self::Error> {
         match quither {
-            Quither::<L, R, true, true, has_both>::Left(l) => Err(EitherOrNeither::Left(l)),
-            Quither::<L, R, true, true, has_both>::Right(r) => Err(EitherOrNeither::Right(r)),
-            Quither::<L, R, true, true, has_both>::Neither => Err(EitherOrNeither::Neither),
+            Xither::<L, R, true, true, has_both>::Left(l) => Err(EitherOrNeither::Left(l)),
+            Xither::<L, R, true, true, has_both>::Right(r) => Err(EitherOrNeither::Right(r)),
+            Xither::<L, R, true, true, has_both>::Neither => Err(EitherOrNeither::Neither),
             #[both]
-            Quither::<L, R, true, true, has_both>::Both(l, r) => Ok(Quither::Both(l, r)),
+            Xither::<L, R, true, true, has_both>::Both(l, r) => Ok(Xither::Both(l, r)),
         }
     }
 }
 
 /// Demotes a type with `Either` and `Both` variants to a type without those variants.
 #[quither(!has_either && !has_both)]
-impl<L, R> TryFrom<Quither<L, R, true, has_neither, true>> for Quither<L, R> {
+impl<L, R> TryFrom<Xither<L, R, true, has_neither, true>> for Xither<L, R> {
     type Error = EitherOrBoth<L, R>;
-    fn try_from(quither: Quither<L, R, true, has_neither, true>) -> Result<Self, Self::Error> {
+    fn try_from(quither: Xither<L, R, true, has_neither, true>) -> Result<Self, Self::Error> {
         match quither {
-            Quither::<L, R, true, has_neither, true>::Left(l) => Err(EitherOrBoth::Left(l)),
-            Quither::<L, R, true, has_neither, true>::Right(r) => Err(EitherOrBoth::Right(r)),
+            Xither::<L, R, true, has_neither, true>::Left(l) => Err(EitherOrBoth::Left(l)),
+            Xither::<L, R, true, has_neither, true>::Right(r) => Err(EitherOrBoth::Right(r)),
             #[neither]
-            Quither::<L, R, true, has_neither, true>::Neither => Ok(Quither::Neither),
-            Quither::<L, R, true, has_neither, true>::Both(l, r) => Err(EitherOrBoth::Both(l, r)),
+            Xither::<L, R, true, has_neither, true>::Neither => Ok(Xither::Neither),
+            Xither::<L, R, true, has_neither, true>::Both(l, r) => Err(EitherOrBoth::Both(l, r)),
         }
     }
 }
 
 /// Demotes a type with `Either` and `Neither` variants to a type without those variants.
 #[quither(!has_neither && !has_both)]
-impl<L, R> TryFrom<Quither<L, R, has_either, true, true>> for Quither<L, R> {
+impl<L, R> TryFrom<Xither<L, R, has_either, true, true>> for Xither<L, R> {
     type Error = NeitherOrBoth<L, R>;
-    fn try_from(quither: Quither<L, R, has_either, true, true>) -> Result<Self, Self::Error> {
+    fn try_from(quither: Xither<L, R, has_either, true, true>) -> Result<Self, Self::Error> {
         match quither {
             #[either]
-            Quither::<L, R, has_either, true, true>::Left(l) => Ok(Quither::Left(l)),
+            Xither::<L, R, has_either, true, true>::Left(l) => Ok(Xither::Left(l)),
             #[either]
-            Quither::<L, R, has_either, true, true>::Right(r) => Ok(Quither::Right(r)),
-            Quither::<L, R, has_either, true, true>::Neither => Err(NeitherOrBoth::Neither),
-            Quither::<L, R, has_either, true, true>::Both(l, r) => Err(NeitherOrBoth::Both(l, r)),
+            Xither::<L, R, has_either, true, true>::Right(r) => Ok(Xither::Right(r)),
+            Xither::<L, R, has_either, true, true>::Neither => Err(NeitherOrBoth::Neither),
+            Xither::<L, R, has_either, true, true>::Both(l, r) => Err(NeitherOrBoth::Both(l, r)),
         }
     }
 }

--- a/quither/src/factor.rs
+++ b/quither/src/factor.rs
@@ -16,7 +16,7 @@ use super::*;
 use quither_proc_macros::quither;
 
 #[quither]
-impl<L, R> Quither<L, R> {
+impl<L, R> Xither<L, R> {
     /// Factor out the `Neither` variant out from the type, converting the type into
     /// `Option<NewType>>`, where `NewType` is the type of the type excluding the `Neither` variant.
     ///
@@ -24,22 +24,22 @@ impl<L, R> Quither<L, R> {
     /// Converts the value into an Option of a type that does not include the Neither variant. Returns
     /// None if the value is Neither; otherwise, returns Some with the corresponding variant.
     #[quither(has_neither && (has_either || has_both))]
-    pub fn factor_neither(self) -> Option<Quither<L, R, has_either, false, has_both>> {
+    pub fn factor_neither(self) -> Option<Xither<L, R, has_either, false, has_both>> {
         match self {
             #[either]
-            Self::Left(l) => Some(Quither::<L, R, has_either, false, has_both>::Left(l)),
+            Self::Left(l) => Some(Xither::<L, R, has_either, false, has_both>::Left(l)),
             #[either]
-            Self::Right(r) => Some(Quither::<L, R, has_either, false, has_both>::Right(r)),
+            Self::Right(r) => Some(Xither::<L, R, has_either, false, has_both>::Right(r)),
             #[neither]
             Self::Neither => None,
             #[both]
-            Self::Both(l, r) => Some(Quither::<L, R, has_either, false, has_both>::Both(l, r)),
+            Self::Both(l, r) => Some(Xither::<L, R, has_either, false, has_both>::Both(l, r)),
         }
     }
 }
 
 #[quither]
-impl<L, R> Quither<Option<L>, Option<R>> {
+impl<L, R> Xither<Option<L>, Option<R>> {
     /// Factors out None values from a pair of Options, returning None if both are None.
     ///
     /// For types of pairs of Option, this method returns an Option of a pair type without Option.
@@ -48,20 +48,20 @@ impl<L, R> Quither<Option<L>, Option<R>> {
     /// variants present. See also the note about Both types returning EitherOrBoth.
     pub fn factor_none(
         self,
-    ) -> Option<Quither<L, R, { has_both || has_either }, has_neither, has_both>> {
+    ) -> Option<Xither<L, R, { has_both || has_either }, has_neither, has_both>> {
         #[allow(unused)]
-        type Quither2<L, R> = Quither<L, R, { has_both || has_either }, has_neither, has_both>;
+        type Xither2<L, R> = Xither<L, R, { has_both || has_either }, has_neither, has_both>;
         match self {
             #[either]
-            Self::Left(Some(l)) => Some(Quither2::Left(l)),
+            Self::Left(Some(l)) => Some(Xither2::Left(l)),
             #[either]
-            Self::Right(Some(r)) => Some(Quither2::Right(r)),
+            Self::Right(Some(r)) => Some(Xither2::Right(r)),
             #[both]
-            Self::Both(Some(l), Some(r)) => Some(Quither2::Both(l, r)),
+            Self::Both(Some(l), Some(r)) => Some(Xither2::Both(l, r)),
             #[both]
-            Self::Both(Some(l), None) => Some(Quither2::Left(l)),
+            Self::Both(Some(l), None) => Some(Xither2::Left(l)),
             #[both]
-            Self::Both(None, Some(r)) => Some(Quither2::Right(r)),
+            Self::Both(None, Some(r)) => Some(Xither2::Right(r)),
             _ => None,
         }
     }

--- a/quither/src/get_or_insert.rs
+++ b/quither/src/get_or_insert.rs
@@ -17,7 +17,7 @@ use ::replace_with::replace_with_or_abort;
 use quither_proc_macros::quither;
 
 #[quither]
-impl<L, R> Quither<L, R> {
+impl<L, R> Xither<L, R> {
     /// Inserts a left value if not present and returns a mutable reference to it.
     ///
     /// If the left value is already present, returns it. If the current variant is `Right`, promotes

--- a/quither/src/getters.rs
+++ b/quither/src/getters.rs
@@ -17,7 +17,7 @@ use ::core::fmt::Debug;
 use quither_proc_macros::quither;
 
 #[quither]
-impl<L, R> Quither<L, R> {
+impl<L, R> Xither<L, R> {
     /// Returns true if the value contains a left value.
     pub fn has_left(&self) -> bool {
         match self {
@@ -157,16 +157,16 @@ impl<L, R> Quither<L, R> {
     }
 
     /// Returns a new value with left and right swapped.
-    pub fn flip(self) -> Quither<R, L> {
+    pub fn flip(self) -> Xither<R, L> {
         match self {
             #[either]
-            Self::Left(l) => Quither::Right(l),
+            Self::Left(l) => Xither::Right(l),
             #[either]
-            Self::Right(r) => Quither::Left(r),
+            Self::Right(r) => Xither::Left(r),
             #[neither]
-            Self::Neither => Quither::Neither,
+            Self::Neither => Xither::Neither,
             #[both]
-            Self::Both(l, r) => Quither::Both(r, l),
+            Self::Both(l, r) => Xither::Both(r, l),
         }
     }
 

--- a/quither/src/into.rs
+++ b/quither/src/into.rs
@@ -16,7 +16,7 @@ use super::*;
 use quither_proc_macros::quither;
 
 #[quither]
-impl<L, R> Quither<L, R> {
+impl<L, R> Xither<L, R> {
     #[quither(!has_neither)]
     /// Converts to the left value, consuming self.
     ///

--- a/quither/src/iter.rs
+++ b/quither/src/iter.rs
@@ -20,7 +20,7 @@ use quither_proc_macros::quither;
 use core::iter::{Chain, Flatten};
 
 #[quither]
-impl<L, R> Quither<L, R> {
+impl<L, R> Xither<L, R> {
     #[deprecated(note = "This method's intention is unclear. Use `into_iter_chained()` instead.")]
     #[quither(has_either && !has_neither && !has_both)]
     pub fn into_iter(self) -> Either<L::IntoIter, R::IntoIter>
@@ -602,12 +602,12 @@ where
 pub type IterEither<L, R> = IterIntoEither<L, R>;
 
 #[quither(has_either || has_both)]
-impl<L, R> From<Quither<L, R>> for IterIntoEither<L, R>
+impl<L, R> From<Xither<L, R>> for IterIntoEither<L, R>
 where
     L: Iterator,
     R: Iterator,
 {
-    fn from(q: Quither<L, R>) -> Self {
+    fn from(q: Xither<L, R>) -> Self {
         IterIntoEither(q.into())
     }
 }
@@ -702,12 +702,12 @@ where
     R: Iterator;
 
 #[quither(has_either || has_both)]
-impl<L, R> From<Quither<L, R>> for IterIntoEitherOrBoth<L, R>
+impl<L, R> From<Xither<L, R>> for IterIntoEitherOrBoth<L, R>
 where
     L: Iterator,
     R: Iterator,
 {
-    fn from(q: Quither<L, R>) -> Self {
+    fn from(q: Xither<L, R>) -> Self {
         IterIntoEitherOrBoth(q.into())
     }
 }
@@ -776,12 +776,12 @@ where
     R: Iterator;
 
 #[quither(has_either || has_both)]
-impl<L, R> From<Quither<L, R>> for IterIntoBoth<L, R>
+impl<L, R> From<Xither<L, R>> for IterIntoBoth<L, R>
 where
     L: Iterator,
     R: Iterator,
 {
-    fn from(q: Quither<L, R>) -> Self {
+    fn from(q: Xither<L, R>) -> Self {
         IterIntoBoth(q.both().map(|(l, r)| Both::Both(l, r)))
     }
 }
@@ -850,12 +850,12 @@ where
     R: Iterator<Item = L::Item>;
 
 #[quither(has_either || has_both)]
-impl<L, R> From<Quither<L, R>> for ChainedIterator<L, R>
+impl<L, R> From<Xither<L, R>> for ChainedIterator<L, R>
 where
     L: Iterator,
     R: Iterator<Item = L::Item>,
 {
-    fn from(q: Quither<L, R>) -> Self {
+    fn from(q: Xither<L, R>) -> Self {
         let (left, right) = q.left_and_right();
         ChainedIterator(
             left.into_iter()

--- a/quither/src/map.rs
+++ b/quither/src/map.rs
@@ -16,27 +16,27 @@ use super::*;
 use quither_proc_macros::quither;
 
 #[quither]
-impl<L, R> Quither<L, R> {
+impl<L, R> Xither<L, R> {
     /// Applies separate functions to each variant, transforming both sides.
     ///
     /// For types with `Either` or `Both` variants, applies `f` to the left value and `g` to the right
     /// value, returning a new pair type with the results. If `Both` is present, both functions are
     /// applied. If `Neither` is present, returns `Neither`.
     #[quither(has_either || has_both)]
-    pub fn map2<F, G, L2, R2>(self, f: F, g: G) -> Quither<L2, R2>
+    pub fn map2<F, G, L2, R2>(self, f: F, g: G) -> Xither<L2, R2>
     where
         F: FnOnce(L) -> L2,
         G: FnOnce(R) -> R2,
     {
         match self {
             #[either]
-            Self::Left(l) => Quither::Left(f(l)),
+            Self::Left(l) => Xither::Left(f(l)),
             #[either]
-            Self::Right(r) => Quither::Right(g(r)),
+            Self::Right(r) => Xither::Right(g(r)),
             #[neither]
-            Self::Neither => Quither::Neither,
+            Self::Neither => Xither::Neither,
             #[both]
-            Self::Both(l, r) => Quither::Both(f(l), g(r)),
+            Self::Both(l, r) => Xither::Both(f(l), g(r)),
         }
     }
 
@@ -46,19 +46,19 @@ impl<L, R> Quither<L, R> {
     /// unchanged. If `Both` is present, only the left value is transformed. If `Neither` is present,
     /// returns `Neither`.
     #[quither(has_either || has_both)]
-    pub fn map_left<F, L2>(self, f: F) -> Quither<L2, R>
+    pub fn map_left<F, L2>(self, f: F) -> Xither<L2, R>
     where
         F: FnOnce(L) -> L2,
     {
         match self {
             #[either]
-            Self::Left(l) => Quither::Left(f(l)),
+            Self::Left(l) => Xither::Left(f(l)),
             #[either]
-            Self::Right(r) => Quither::Right(r),
+            Self::Right(r) => Xither::Right(r),
             #[neither]
-            Self::Neither => Quither::Neither,
+            Self::Neither => Xither::Neither,
             #[both]
-            Self::Both(l, r) => Quither::Both(f(l), r),
+            Self::Both(l, r) => Xither::Both(f(l), r),
         }
     }
 
@@ -68,19 +68,19 @@ impl<L, R> Quither<L, R> {
     /// unchanged. If `Both` is present, only the right value is transformed. If `Neither` is present,
     /// returns `Neither`.
     #[quither(has_either || has_both)]
-    pub fn map_right<F, R2>(self, f: F) -> Quither<L, R2>
+    pub fn map_right<F, R2>(self, f: F) -> Xither<L, R2>
     where
         F: FnOnce(R) -> R2,
     {
         match self {
             #[either]
-            Self::Left(l) => Quither::Left(l),
+            Self::Left(l) => Xither::Left(l),
             #[either]
-            Self::Right(r) => Quither::Right(f(r)),
+            Self::Right(r) => Xither::Right(f(r)),
             #[neither]
-            Self::Neither => Quither::Neither,
+            Self::Neither => Xither::Neither,
             #[both]
-            Self::Both(l, r) => Quither::Both(l, f(r)),
+            Self::Both(l, r) => Xither::Both(l, f(r)),
         }
     }
 
@@ -90,20 +90,20 @@ impl<L, R> Quither<L, R> {
     /// The functors are applied in strictly `f` then `g` order, and if either functor returns an error,
     /// the following functors are not applied and the error is returned.
     #[quither(has_either || has_both)]
-    pub fn try_map2<F, G, L2, R2, E>(self, f: F, g: G) -> Result<Quither<L2, R2>, E>
+    pub fn try_map2<F, G, L2, R2, E>(self, f: F, g: G) -> Result<Xither<L2, R2>, E>
     where
         F: FnOnce(L) -> Result<L2, E>,
         G: FnOnce(R) -> Result<R2, E>,
     {
         Ok(match self {
             #[either]
-            Self::Left(l) => Quither::Left(f(l)?),
+            Self::Left(l) => Xither::Left(f(l)?),
             #[either]
-            Self::Right(r) => Quither::Right(g(r)?),
+            Self::Right(r) => Xither::Right(g(r)?),
             #[neither]
-            Self::Neither => Quither::Neither,
+            Self::Neither => Xither::Neither,
             #[both]
-            Self::Both(l, r) => Quither::Both(f(l)?, g(r)?),
+            Self::Both(l, r) => Xither::Both(f(l)?, g(r)?),
         })
     }
 
@@ -113,19 +113,19 @@ impl<L, R> Quither<L, R> {
     /// The right value is unchanged. If `Both` is present, only the left value is transformed.
     /// If `Neither` is present, returns `Neither`.
     #[quither(has_either || has_both)]
-    pub fn try_map_left<F, L2, E>(self, f: F) -> Result<Quither<L2, R>, E>
+    pub fn try_map_left<F, L2, E>(self, f: F) -> Result<Xither<L2, R>, E>
     where
         F: FnOnce(L) -> Result<L2, E>,
     {
         Ok(match self {
             #[either]
-            Self::Left(l) => Quither::Left(f(l)?),
+            Self::Left(l) => Xither::Left(f(l)?),
             #[either]
-            Self::Right(r) => Quither::Right(r),
+            Self::Right(r) => Xither::Right(r),
             #[neither]
-            Self::Neither => Quither::Neither,
+            Self::Neither => Xither::Neither,
             #[both]
-            Self::Both(l, r) => Quither::Both(f(l)?, r),
+            Self::Both(l, r) => Xither::Both(f(l)?, r),
         })
     }
 
@@ -135,19 +135,19 @@ impl<L, R> Quither<L, R> {
     /// The left value is unchanged. If `Both` is present, only the right value is transformed.
     /// If `Neither` is present, returns `Neither`.
     #[quither(has_either || has_both)]
-    pub fn try_map_right<F, R2, E>(self, f: F) -> Result<Quither<L, R2>, E>
+    pub fn try_map_right<F, R2, E>(self, f: F) -> Result<Xither<L, R2>, E>
     where
         F: FnOnce(R) -> Result<R2, E>,
     {
         Ok(match self {
             #[either]
-            Self::Left(l) => Quither::Left(l),
+            Self::Left(l) => Xither::Left(l),
             #[either]
-            Self::Right(r) => Quither::Right(f(r)?),
+            Self::Right(r) => Xither::Right(f(r)?),
             #[neither]
-            Self::Neither => Quither::Neither,
+            Self::Neither => Xither::Neither,
             #[both]
-            Self::Both(l, r) => Quither::Both(l, f(r)?),
+            Self::Both(l, r) => Xither::Both(l, f(r)?),
         })
     }
 
@@ -157,18 +157,18 @@ impl<L, R> Quither<L, R> {
     /// both with the provided context. Returns a new pair type with the results. If `Neither` is
     /// present, returns `Neither`.
     #[quither(has_either && !has_both)]
-    pub fn map_with<Ctx, F, G, L2, R2>(self, ctx: Ctx, f: F, g: G) -> Quither<L2, R2>
+    pub fn map_with<Ctx, F, G, L2, R2>(self, ctx: Ctx, f: F, g: G) -> Xither<L2, R2>
     where
         F: FnOnce(Ctx, L) -> L2,
         G: FnOnce(Ctx, R) -> R2,
     {
         match self {
             #[either]
-            Self::Left(l) => Quither::Left(f(ctx, l)),
+            Self::Left(l) => Xither::Left(f(ctx, l)),
             #[either]
-            Self::Right(r) => Quither::Right(g(ctx, r)),
+            Self::Right(r) => Xither::Right(g(ctx, r)),
             #[neither]
-            Self::Neither => Quither::Neither,
+            Self::Neither => Xither::Neither,
         }
     }
 
@@ -178,7 +178,7 @@ impl<L, R> Quither<L, R> {
     /// both with a cloned context. If `Both` is present, both functions are applied with cloned
     /// contexts. If `Neither` is present, returns `Neither`.
     #[quither(has_either && has_both)]
-    pub fn map_with<Ctx, F, G, L2, R2>(self, ctx: Ctx, f: F, g: G) -> Quither<L2, R2>
+    pub fn map_with<Ctx, F, G, L2, R2>(self, ctx: Ctx, f: F, g: G) -> Xither<L2, R2>
     where
         Ctx: Clone,
         F: FnOnce(Ctx, L) -> L2,
@@ -186,19 +186,19 @@ impl<L, R> Quither<L, R> {
     {
         match self {
             #[either]
-            Self::Left(l) => Quither::Left(f(ctx, l)),
+            Self::Left(l) => Xither::Left(f(ctx, l)),
             #[either]
-            Self::Right(r) => Quither::Right(g(ctx, r)),
+            Self::Right(r) => Xither::Right(g(ctx, r)),
             #[neither]
-            Self::Neither => Quither::Neither,
+            Self::Neither => Xither::Neither,
             #[both]
-            Self::Both(l, r) => Quither::Both(f(ctx.clone(), l), g(ctx.clone(), r)),
+            Self::Both(l, r) => Xither::Both(f(ctx.clone(), l), g(ctx.clone(), r)),
         }
     }
 }
 
 #[quither]
-impl<T> Quither<T, T> {
+impl<T> Xither<T, T> {
     /// Applies a function to both values, for types with identical left and right types, without `Both`.
     ///
     /// For types with `Either` but not `Both`, applies `f` to both values. If `Neither` is present,
@@ -206,17 +206,17 @@ impl<T> Quither<T, T> {
     /// If the type has `Both` variant, then this method has slightly stricter functor bounds
     /// (`FnOnce` -> `FnMut`).
     #[quither(has_either && !has_both)]
-    pub fn map<F, T2>(self, f: F) -> Quither<T2, T2>
+    pub fn map<F, T2>(self, f: F) -> Xither<T2, T2>
     where
         F: FnOnce(T) -> T2,
     {
         match self {
             #[either]
-            Quither::Left(l) => Quither::Left(f(l)),
+            Xither::Left(l) => Xither::Left(f(l)),
             #[either]
-            Quither::Right(r) => Quither::Right(f(r)),
+            Xither::Right(r) => Xither::Right(f(r)),
             #[neither]
-            Quither::Neither => Quither::Neither,
+            Xither::Neither => Xither::Neither,
         }
     }
 
@@ -224,19 +224,19 @@ impl<T> Quither<T, T> {
     ///
     /// For types with `Both` variant, applies `f` to the left value and the right value, in this order.
     #[quither(has_either && has_both)]
-    pub fn map<F, T2>(self, mut f: F) -> Quither<T2, T2>
+    pub fn map<F, T2>(self, mut f: F) -> Xither<T2, T2>
     where
         F: FnMut(T) -> T2,
     {
         match self {
             #[either]
-            Quither::Left(l) => Quither::Left(f(l)),
+            Xither::Left(l) => Xither::Left(f(l)),
             #[either]
-            Quither::Right(r) => Quither::Right(f(r)),
+            Xither::Right(r) => Xither::Right(f(r)),
             #[neither]
-            Quither::Neither => Quither::Neither,
+            Xither::Neither => Xither::Neither,
             #[both]
-            Quither::Both(l, r) => Quither::Both(f(l), f(r)),
+            Xither::Both(l, r) => Xither::Both(f(l), f(r)),
         }
     }
 
@@ -247,17 +247,17 @@ impl<T> Quither<T, T> {
     /// If the type has `Both` variant, then this method has slightly stricter functor bounds
     /// (`FnOnce` -> `FnMut`).
     #[quither(has_either && !has_both)]
-    pub fn try_map<F, T2, E>(self, f: F) -> Result<Quither<T2, T2>, E>
+    pub fn try_map<F, T2, E>(self, f: F) -> Result<Xither<T2, T2>, E>
     where
         F: FnOnce(T) -> Result<T2, E>,
     {
         Ok(match self {
             #[either]
-            Quither::Left(l) => Quither::Left(f(l)?),
+            Xither::Left(l) => Xither::Left(f(l)?),
             #[either]
-            Quither::Right(r) => Quither::Right(f(r)?),
+            Xither::Right(r) => Xither::Right(f(r)?),
             #[neither]
-            Quither::Neither => Quither::Neither,
+            Xither::Neither => Xither::Neither,
         })
     }
 
@@ -266,19 +266,19 @@ impl<T> Quither<T, T> {
     /// Applies `f` to both left and right existing values in this order, and if any of the
     /// functor calls return an error, then the error is returned.
     #[quither(has_either && has_both)]
-    pub fn try_map<F, T2, E>(self, mut f: F) -> Result<Quither<T2, T2>, E>
+    pub fn try_map<F, T2, E>(self, mut f: F) -> Result<Xither<T2, T2>, E>
     where
         F: FnMut(T) -> Result<T2, E>,
     {
         Ok(match self {
             #[either]
-            Quither::Left(l) => Quither::Left(f(l)?),
+            Xither::Left(l) => Xither::Left(f(l)?),
             #[either]
-            Quither::Right(r) => Quither::Right(f(r)?),
+            Xither::Right(r) => Xither::Right(f(r)?),
             #[neither]
-            Quither::Neither => Quither::Neither,
+            Xither::Neither => Xither::Neither,
             #[both]
-            Quither::Both(l, r) => Quither::Both(f(l)?, f(r)?),
+            Xither::Both(l, r) => Xither::Both(f(l)?, f(r)?),
         })
     }
 }

--- a/quither/src/std_impls.rs
+++ b/quither/src/std_impls.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! A file to implement standard traits for `Quither` types.
+//! A file to implement standard traits for `Xither` types.
 //!
 //! Note some of the `std` traits like `AsRef`, `AsMut` are in other file ([`as_ref.rs`]).
 
@@ -34,7 +34,7 @@ use ::std::io::{BufRead, Read, Result as IoResult, Seek, SeekFrom};
 /// `std::io::Read::chain`, which never retries the first reader after it returns 0 bytes.
 #[cfg(feature = "use_std")]
 #[quither]
-impl<L, R> Read for Quither<L, R>
+impl<L, R> Read for Xither<L, R>
 where
     L: Read,
     R: Read,
@@ -71,7 +71,7 @@ where
 /// `std::io::Read::chain` instead.
 #[cfg(feature = "use_std")]
 #[quither(!has_both)]
-impl<L, R> BufRead for Quither<L, R>
+impl<L, R> BufRead for Xither<L, R>
 where
     L: BufRead,
     R: BufRead,
@@ -106,7 +106,7 @@ where
 /// variant.
 #[cfg(feature = "use_std")]
 #[quither(!has_both)]
-impl<L, R> Seek for Quither<L, R>
+impl<L, R> Seek for Xither<L, R>
 where
     L: Seek,
     R: Seek,
@@ -164,7 +164,7 @@ where
 /// Requires both `L: Display` and `R: Display`. The output format reflects the variant and its
 /// inner value(s).
 #[quither]
-impl<L, R> Display for Quither<L, R>
+impl<L, R> Display for Xither<L, R>
 where
     L: Display,
     R: Display,
@@ -224,7 +224,7 @@ where
 /// that do not include the Neither or Both variants. If the type includes the Both variant, use the
 /// implementation that requires `T: Clone`, which extends both inner values with cloned items.
 #[quither(!has_neither && !has_both)]
-impl<L, R, T> Extend<T> for Quither<L, R>
+impl<L, R, T> Extend<T> for Xither<L, R>
 where
     L: Extend<T>,
     R: Extend<T>,
@@ -244,7 +244,7 @@ where
 /// Requires `L: Extend<T>`, `R: Extend<T>`, and `T: Clone`. For types that include the Both variant,
 /// both inner values are extended with cloned items from the iterator.
 #[quither(!has_neither && has_both)]
-impl<L, R, T> Extend<T> for Quither<L, R>
+impl<L, R, T> Extend<T> for Xither<L, R>
 where
     L: Extend<T>,
     R: Extend<T>,
@@ -295,21 +295,21 @@ where
 }
 
 #[quither]
-impl<L, R, OL, OR> PartialEq<Quither<OL, OR>> for Quither<L, R>
+impl<L, R, OL, OR> PartialEq<Xither<OL, OR>> for Xither<L, R>
 where
     L: PartialEq<OL>,
     R: PartialEq<OR>,
 {
-    fn eq(&self, other: &Quither<OL, OR>) -> bool {
+    fn eq(&self, other: &Xither<OL, OR>) -> bool {
         match (self, other) {
             #[either]
-            (Self::Left(l), Quither::Left(ol)) => l == ol,
+            (Self::Left(l), Xither::Left(ol)) => l == ol,
             #[either]
-            (Self::Right(r), Quither::Right(or)) => r == or,
+            (Self::Right(r), Xither::Right(or)) => r == or,
             #[neither]
-            (Self::Neither, Quither::Neither) => true,
+            (Self::Neither, Xither::Neither) => true,
             #[both]
-            (Self::Both(l, r), Quither::Both(ol, or)) => l == ol && r == or,
+            (Self::Both(l, r), Xither::Both(ol, or)) => l == ol && r == or,
             #[allow(unreachable_patterns)]
             _ => false,
         }
@@ -317,21 +317,21 @@ where
 }
 
 #[quither]
-impl<L, R, OL, OR> PartialOrd<Quither<OL, OR>> for Quither<L, R>
+impl<L, R, OL, OR> PartialOrd<Xither<OL, OR>> for Xither<L, R>
 where
     L: PartialOrd<OL>,
     R: PartialOrd<OR>,
 {
-    fn partial_cmp(&self, other: &Quither<OL, OR>) -> Option<std::cmp::Ordering> {
+    fn partial_cmp(&self, other: &Xither<OL, OR>) -> Option<std::cmp::Ordering> {
         match (self, other) {
             #[either]
-            (Self::Left(l), Quither::Left(ol)) => l.partial_cmp(ol),
+            (Self::Left(l), Xither::Left(ol)) => l.partial_cmp(ol),
             #[either]
-            (Self::Right(r), Quither::Right(or)) => r.partial_cmp(or),
+            (Self::Right(r), Xither::Right(or)) => r.partial_cmp(or),
             #[neither]
-            (Self::Neither, Quither::Neither) => Some(std::cmp::Ordering::Equal),
+            (Self::Neither, Xither::Neither) => Some(std::cmp::Ordering::Equal),
             #[both]
-            (Self::Both(l, r), Quither::Both(ol, or)) => l
+            (Self::Both(l, r), Xither::Both(ol, or)) => l
                 .partial_cmp(ol)
                 .and_then(|o| r.partial_cmp(or).map(|o2| o.cmp(&o2))),
             // Non-equal variants patterns
@@ -340,19 +340,19 @@ where
             (Self::Neither, _) => Some(std::cmp::Ordering::Less),
             #[neither]
             #[allow(unreachable_patterns)]
-            (_, Quither::Neither) => Some(std::cmp::Ordering::Greater),
+            (_, Xither::Neither) => Some(std::cmp::Ordering::Greater),
             #[either]
             #[allow(unreachable_patterns)]
             (Self::Left(_), _) => Some(std::cmp::Ordering::Less),
             #[either]
             #[allow(unreachable_patterns)]
-            (_, Quither::Left(_)) => Some(std::cmp::Ordering::Greater),
+            (_, Xither::Left(_)) => Some(std::cmp::Ordering::Greater),
             #[either]
             #[allow(unreachable_patterns)]
             (Self::Right(_), _) => Some(std::cmp::Ordering::Less),
             #[either]
             #[allow(unreachable_patterns)]
-            (_, Quither::Right(_)) => Some(std::cmp::Ordering::Greater),
+            (_, Xither::Right(_)) => Some(std::cmp::Ordering::Greater),
         }
     }
 }


### PR DESCRIPTION
For the deconfusion of the multiple usages of the name `Quither`, replace it by `Xither` for the placeholder in `#[quither]` proc-macro.